### PR TITLE
OP-1037: Validation of contributions receipt

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,6 @@
 import {
     graphql,
+    graphqlWithVariables,
     formatPageQuery,
     formatPageQueryWithCount,
     formatMutation,
@@ -85,8 +86,9 @@ export function fetchPolicySummary(
   }
   const payload = formatPageQuery("policies",
     filters,
-    ["id", "uuid", "startDate", "product{name}", "expiryDate", "value"],
+    ["id", "uuid", "startDate", "product{name, code}", "expiryDate", "value"],
   );
+  console.log("payload", payload);
   return graphql(payload, 'CONTRIBUTION_POLICY_SUMMARY');
 }
 
@@ -146,7 +148,6 @@ export function updateContribution(mm, contribution, clientMutationLabel) {
   )
 }
 
-
 export function deleteContribution(mm, contribution, clientMutationLabel) {
   let mutation = formatMutation("deletePremium", `uuids: ["${contribution.uuid}"]`, clientMutationLabel);
   contribution.clientMutationId = mutation.clientMutationId;
@@ -161,4 +162,28 @@ export function deleteContribution(mm, contribution, clientMutationLabel) {
       contributionUuid: contribution.uuid,
     }
   )
+}
+
+export function clearContribution() {
+  return (dispatch) => {
+    dispatch({ type: `CONTRIBUTION_OVERVIEW_CLEAR` });
+  };
+}
+
+export function validateReceipt(mm, variables) {
+  return graphqlWithVariables(
+    `
+    query ($code: String!, $policyUuid: String!) {
+      isValid: validatePremiumCode(code: $code, policyUuid: $policyUuid)
+    }
+    `,
+    variables,
+    `CONTRIBUTION_FIELDS_VALIDATION`,
+  );
+}
+
+export function clearReceiptValidation(mm) {
+  return (dispatch) => {
+    dispatch({ type: `CONTRIBUTION_FIELDS_VALIDATION_CLEAR` });
+  };
 }

--- a/src/components/ContributionForm.js
+++ b/src/components/ContributionForm.js
@@ -2,15 +2,16 @@ import React, { Component } from "react";
 import { injectIntl } from 'react-intl';
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import ReplayIcon from "@material-ui/icons/Replay"
+
 import {
     formatMessageWithValues, withModulesManager, withHistory,
     Form, ProgressOrError, journalize, coreConfirm, Helmet
 } from "@openimis/fe-core";
+import { fetchContribution, newContribution, createContribution, fetchPolicySummary, clearContribution } from "../actions";
 import { RIGHT_CONTRIBUTION } from "../constants";
-
-import { fetchContribution, newContribution, createContribution, fetchPolicySummary } from "../actions";
 import ContributionMasterPanel from "./ContributionMasterPanel";
 import SaveContributionDialog from "./SaveContributionDialog";
 
@@ -96,7 +97,10 @@ class ContributionForm extends Component {
             }));
         }
     }
-
+    
+    componentWillUnmount = () => {
+        this.props.clearContribution();
+    };
 
     reload = () => {
         const { contribution } = this.state;
@@ -109,6 +113,7 @@ class ContributionForm extends Component {
 
     canSave = () => {
         const { contribution } = this.state;
+        const { isReceiptValid } = this.props;
         if (!contribution ||
             (contribution && (
                 !contribution.payDate ||
@@ -116,7 +121,8 @@ class ContributionForm extends Component {
                 !contribution.amount ||
                 !contribution.receipt ||
                 !contribution.policy ||
-                (contribution.policy && !contribution.policy.uuid)
+                (contribution.policy && !contribution.policy.uuid) ||
+                !isReceiptValid
             ))) return false;
         return true;
     }
@@ -239,6 +245,7 @@ const mapStateToProps = (state, props) => ({
     contribution: state.contribution.contribution,
     confirmed: state.core.confirmed,
     state: state,
+    isReceiptValid: state.contribution?.validationFields?.contributionReceipt.isValid,
 })
 
 const mapDispatchToProps = dispatch => {
@@ -247,6 +254,7 @@ const mapDispatchToProps = dispatch => {
         fetchPolicySummary,
         newContribution,
         createContribution,
+        clearContribution,
         journalize,
         coreConfirm,
     }, dispatch);

--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -1,140 +1,170 @@
 import React, { Fragment } from "react";
+import { connect } from "react-redux";
+import { injectIntl } from "react-intl";
+
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { injectIntl } from 'react-intl';
+import { Grid } from "@material-ui/core";
+
 import {
-    Grid,
-} from "@material-ui/core";
-import {
-    withHistory,
-    withModulesManager,
-    AmountInput,
-    TextInput,
-    PublishedComponent,
-    FormPanel
+  withHistory,
+  withModulesManager,
+  AmountInput,
+  TextInput,
+  ValidatedTextInput,
+  PublishedComponent,
+  formatMessageWithValues,
+  FormPanel,
 } from "@openimis/fe-core";
+import { validateReceipt, clearReceiptValidation } from "../actions";
 
-
-const styles = theme => ({
-    tableTitle: theme.table.title,
-    item: theme.paper.item,
-    fullHeight: {
-        height: "100%"
-    },
+const styles = (theme) => ({
+  tableTitle: theme.table.title,
+  item: theme.paper.item,
+  fullHeight: {
+    height: "100%",
+  },
 });
 
 class ContributionMasterPanel extends FormPanel {
-    render() {
-        const {
-            classes,
-            edited,
-            readOnly,
-        } = this.props;
-        return (
-            <Fragment>
-                {!!edited && !!edited.policy && !!edited.policy.value  && (
-                    <Grid container className={classes.item}>
-                        <Grid item xs={3} className={classes.item}>
-                            <TextInput
-                                module="contribution"
-                                label="contribution.policy.name"
-                                readOnly={true}
-                                value={(edited.policy.product && edited.policy.product.name)|| ""}
-                            />
-                        </Grid>
-                        <Grid item xs={3} className={classes.item}>
-                            <AmountInput
-                                module="contribution"
-                                label="contribution.policy.value"
-                                required
-                                readOnly={true}
-                                value={edited.policy.value || ""}
-                            />
-                        </Grid>
-                        <Grid item xs={3} className={classes.item}>
-                            <PublishedComponent pubRef="core.DatePicker"
-                                value={edited.policy.startDate || ""}
-                                module="contribution"
-                                label="contribution.policy.startDate"
-                                readOnly={true}
-                            />
-                        </Grid>
-                        <Grid item xs={3} className={classes.item}>
-                            <PublishedComponent pubRef="core.DatePicker"
-                                value={edited.policy.expiryDate || ""}
-                                module="contribution"
-                                label="contribution.policy.expiryDate"
-                                readOnly={true}
-                            />
-                        </Grid>
-                    </Grid>
-                )}
-                <Grid container className={classes.item}>
-                    <Grid item xs={3} className={classes.item}>
-                        <PublishedComponent pubRef="core.DatePicker"
-                            value={!edited ? "" : edited.payDate}
-                            module="contribution"
-                            required
-                            label="contribution.payDate"
-                            readOnly={readOnly}
-                            onChange={c => this.updateAttribute('payDate', c)}
-                        />
-                    </Grid>
-                    <Grid item xs={3} className={classes.item}>
-                        <PublishedComponent
-                            pubRef="payer.PayerPicker"
-                            withNull={true}
-                            readOnly={readOnly}
-                            value={!edited ? "" : edited.payer}
-                            onChange={p => this.updateAttribute('payer', p)}
-                        />
-                    </Grid>
-                    <Grid item xs={3} className={classes.item}>
-                        <AmountInput
-                            module="contribution"
-                            label="contribution.amount"
-                            required
-                            readOnly={readOnly}
-                            value={!edited ? "" : edited.amount}
-                            onChange={c => this.updateAttribute('amount', c)}
-                        />
-                    </Grid>
-                    <Grid item xs={3} className={classes.item}>
-                        <PublishedComponent
-                            pubRef="contribution.PremiumPaymentTypePicker"
-                            withNull={true}
-                            required
-                            readOnly={readOnly}
-                            value={!edited ? "" : edited.payType}
-                            onChange={c => this.updateAttribute('payType', c)}
-                        />
-                    </Grid>
-                    <Grid item xs={3} className={classes.item}>
-                        <TextInput
-                            module="contribution"
-                            label="contribution.receipt"
-                            required
-                            readOnly={readOnly}
-                            value={!edited ? "" : edited.receipt}
-                            onChange={c => this.updateAttribute('receipt', c)}
-                        />
-                    </Grid>
-                    <Grid item xs={3} className={classes.item}>
-                        <PublishedComponent
-                            pubRef="contribution.PremiumCategoryPicker"
-                            withNull={false}
-                            readOnly={readOnly}
-                            value={edited && edited.isPhotoFee ? 'photoFee' : 'contribution'}
-                            onChange={c => {
-                                return this.updateAttribute('isPhotoFee', c === 'photoFee');
-                            }}
-                        />
-                    </Grid>
-                </Grid>
-            </Fragment>
-        );
-    }
+  shouldValidate = (inputValue) => {
+    const { savedCode } = this.props;
+    const shouldValidate = inputValue !== savedCode;
+    return shouldValidate;
+  }
+
+  render() {
+    const { intl, classes, edited, readOnly, isReceiptValid, isReceiptValidating, receiptValidationError} = this.props;
+    const productCode = edited?.policy?.product?.code;
+
+    return (
+      <Fragment>
+        {!!edited && !!edited.policy && !!edited.policy.value && (
+          <Grid container className={classes.item}>
+            <Grid item xs={3} className={classes.item}>
+              <TextInput
+                module="contribution"
+                label="contribution.policy.name"
+                readOnly={true}
+                value={
+                  (edited.policy.product && edited.policy.product.name) || ""
+                }
+              />
+            </Grid>
+            <Grid item xs={3} className={classes.item}>
+              <AmountInput
+                module="contribution"
+                label="contribution.policy.value"
+                required
+                readOnly={true}
+                value={edited.policy.value || ""}
+              />
+            </Grid>
+            <Grid item xs={3} className={classes.item}>
+              <PublishedComponent
+                pubRef="core.DatePicker"
+                value={edited.policy.startDate || ""}
+                module="contribution"
+                label="contribution.policy.startDate"
+                readOnly={true}
+              />
+            </Grid>
+            <Grid item xs={3} className={classes.item}>
+              <PublishedComponent
+                pubRef="core.DatePicker"
+                value={edited.policy.expiryDate || ""}
+                module="contribution"
+                label="contribution.policy.expiryDate"
+                readOnly={true}
+              />
+            </Grid>
+          </Grid>
+        )}
+        <Grid container className={classes.item}>
+          <Grid item xs={3} className={classes.item}>
+            <PublishedComponent
+              pubRef="core.DatePicker"
+              value={!edited ? "" : edited.payDate}
+              module="contribution"
+              required
+              label="contribution.payDate"
+              readOnly={readOnly}
+              onChange={(c) => this.updateAttribute("payDate", c)}
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.item}>
+            <PublishedComponent
+              pubRef="payer.PayerPicker"
+              withNull={true}
+              readOnly={readOnly}
+              value={!edited ? "" : edited.payer}
+              onChange={(p) => this.updateAttribute("payer", p)}
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.item}>
+            <AmountInput
+              module="contribution"
+              label="contribution.amount"
+              required
+              readOnly={readOnly}
+              value={!edited ? "" : edited.amount}
+              onChange={(c) => this.updateAttribute("amount", c)}
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.item}>
+            <PublishedComponent
+              pubRef="contribution.PremiumPaymentTypePicker"
+              withNull={true}
+              required
+              readOnly={readOnly}
+              value={!edited ? "" : edited.payType}
+              onChange={(c) => this.updateAttribute("payType", c)}
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.item}>
+          <ValidatedTextInput
+              action={validateReceipt}
+              clearAction={clearReceiptValidation}
+              codeTakenLabel={formatMessageWithValues(intl, "contribution", "alreadyUsed", { productCode })}
+              isValid={isReceiptValid}
+              isValidating={isReceiptValidating}
+              itemQueryIdentifier="code"
+              label="contribution.receipt"
+              module="contribution"
+              onChange={(receipt) => this.updateAttribute("receipt", receipt)}
+              readOnly={readOnly}
+              required={true}
+              additionalQueryArgs={{policyUuid: edited?.policy?.uuid}}
+              shouldValidate={this.shouldValidate}
+              validationError={receiptValidationError}
+              value={edited?.receipt ?? ""}
+            />
+          </Grid>
+          <Grid item xs={3} className={classes.item}>
+            <PublishedComponent
+              pubRef="contribution.PremiumCategoryPicker"
+              withNull={false}
+              readOnly={readOnly}
+              value={edited && edited.isPhotoFee ? "photoFee" : "contribution"}
+              onChange={(c) => {
+                return this.updateAttribute("isPhotoFee", c === "photoFee");
+              }}
+            />
+          </Grid>
+        </Grid>
+      </Fragment>
+    );
+  }
 }
 
-export default withModulesManager(withHistory(injectIntl(withTheme(
-    withStyles(styles)(ContributionMasterPanel)
-))));
+const mapStateToProps = (store) => ({
+  isReceiptValidating: store.contribution?.validationFields?.contributionReceipt.isValidating,
+  isReceiptValid: store.contribution?.validationFields?.contributionReceipt.isValid,
+  receiptValidationError: store.contribution?.validationFields?.contributionReceipt.validationError,
+  savedCode: store.contribution.contribution?.receipt,
+});
+
+export default withModulesManager(
+  withHistory(
+    injectIntl(connect(mapStateToProps)(withTheme(withStyles(styles)(ContributionMasterPanel))))
+  )
+);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -160,6 +160,62 @@ function reducer(
                 contributionsPageInfo : { totalCount: 0 },
                 contribution: null,
             };
+        case "CONTRIBUTION_OVERVIEW_CLEAR":
+            return {
+                ...state,
+                fetchingContribution: false,
+                fetchedContribution: false,
+                contribution: null,
+                errorContribution: null,
+            };
+        case "CONTRIBUTION_FIELDS_VALIDATION_REQ":
+            return {
+                ...state,
+                validationFields: {
+                  ...state.validationFields,
+                  contributionReceipt: {
+                    isValidating: true,
+                    isValid: false,
+                    validationError: null,
+                  },
+                },
+              };
+        case "CONTRIBUTION_FIELDS_VALIDATION_RESP":
+            return {
+                ...state,
+                validationFields: {
+                  ...state.validationFields,
+                  contributionReceipt: {
+                    isValidating: false,
+                    isValid: action.payload?.data.isValid,
+                    validationError: formatGraphQLError(action.payload),
+                  },
+                },
+              };
+        case "CONTRIBUTION_FIELDS_VALIDATION_ERR":
+            return {
+                ...state,
+                validationFields: {
+                  ...state.validationFields,
+                  contributionReceipt: {
+                    isValidating: false,
+                    isValid: false,
+                    validationError: formatServerError(action.payload),
+                  },
+                },
+              };
+        case "CONTRIBUTION_FIELDS_VALIDATION_CLEAR":
+            return {
+                ...state,
+                validationFields: {
+                  ...state.validationFields,
+                  contributionReceipt: {
+                    isValidating: true,
+                    isValid: false,
+                    validationError: null,
+                  },
+                },
+              };
         case 'CONTRIBUTION_MUTATION_REQ':
             return dispatchMutationReq(state, action)
         case 'CONTRIBUTION_MUTATION_ERR':

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9,6 +9,7 @@
     "contribution.category.contribution": "Contribution",
     "contribution.category.null": "Any",
     "contribution.category.photoFee": "Photo Fee",
+    "contribution.alreadyUsed": "Receipt already in use for product {productCode}",
     "contribution.ContributionOverview.newTitle": "Add a contribution",
     "contribution.ContributionOverview.title": "Contribution Details",
     "contribution.contributionSummaries": "{count} contributions Found",


### PR DESCRIPTION
Part of [CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/88)
Part of [POLICY PR](https://github.com/openimis/openimis-fe-policy_js/pull/27)

In scope of this PR, I implemented the validation of receipt codes for contributions. There is no way to have more than one contribution with the same receipt code within an given insurance product. Although I can create contribution with the same code if the products are different.

EDIT: Sorry for the _ContributionMasterPanel.js_ component, where my changes are not precisely marked.