### PR TITLE
OTC-884: Disabled save button in contributions form fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -182,6 +182,12 @@ export function validateReceipt(mm, variables) {
   );
 }
 
+export function setReceiptValid(mm) {
+  return (dispatch) => {
+    dispatch({ type: `CONTRIBUTION_FIELDS_VALIDATION_SET_VALID` });
+  };
+}
+
 export function clearReceiptValidation(mm) {
   return (dispatch) => {
     dispatch({ type: `CONTRIBUTION_FIELDS_VALIDATION_CLEAR` });

--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -15,7 +15,7 @@ import {
   formatMessageWithValues,
   FormPanel,
 } from "@openimis/fe-core";
-import { validateReceipt, clearReceiptValidation } from "../actions";
+import { validateReceipt, clearReceiptValidation, setReceiptValid } from "../actions";
 
 const styles = (theme) => ({
   tableTitle: theme.table.title,
@@ -124,6 +124,7 @@ class ContributionMasterPanel extends FormPanel {
           <ValidatedTextInput
               action={validateReceipt}
               clearAction={clearReceiptValidation}
+              setValidAction={setReceiptValid}
               codeTakenLabel={formatMessageWithValues(intl, "contribution", "alreadyUsed", { productCode })}
               isValid={isReceiptValid}
               isValidating={isReceiptValidating}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -216,6 +216,18 @@ function reducer(
                   },
                 },
               };
+        case "CONTRIBUTION_FIELDS_VALIDATION_SET_VALID":
+            return {
+                ...state,
+                validationFields: {
+                  ...state.validationFields,
+                  contributionReceipt: {
+                    isValidating: false,
+                    isValid: true,
+                    validationError: null,
+                  },
+                },
+              };
         case 'CONTRIBUTION_MUTATION_REQ':
             return dispatchMutationReq(state, action)
         case 'CONTRIBUTION_MUTATION_ERR':


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of isValid by adding an extra action, which sets the state properly when we're editing a receipt no. for the first time. Moreover, there was an issue when we paste an invalid receipt and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ