### PR TITLE
OTC-757: Clearing pagination state if entered the ContributionsPage

### DIFF
--- a/src/pages/ContributionsPage.js
+++ b/src/pages/ContributionsPage.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from 'react-intl';
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { historyPush, withModulesManager, withHistory } from "@openimis/fe-core"
+import { historyPush, withModulesManager, withHistory, clearCurrentPaginationPage } from "@openimis/fe-core"
 import ContributionSearcher from "../components/ContributionSearcher";
 
 
@@ -17,6 +18,12 @@ class ContributionsPage extends Component {
     onDoubleClick = (c, newTab = false) => {
         historyPush(this.props.modulesManager, this.props.history, "contribution.contributionOverview", [c.uuid], newTab)
     }
+
+    componentDidMount = () => {
+        const moduleName = "contribution";
+        const { module } = this.props;
+        if (module !== moduleName) this.props.clearCurrentPaginationPage();
+      };
 
     render() {
         const { classes } = this.props;
@@ -33,8 +40,11 @@ class ContributionsPage extends Component {
 
 const mapStateToProps = state => ({
     rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
+    module: state.core?.savedPagination?.module,
 })
 
+const mapDispatchToProps = (dispatch) => bindActionCreators({ clearCurrentPaginationPage }, dispatch);
+
 export default injectIntl(withModulesManager(
-    withHistory(connect(mapStateToProps)(withTheme(withStyles(styles)(ContributionsPage))))
+    withHistory(connect(mapStateToProps, mapDispatchToProps)(withTheme(withStyles(styles)(ContributionsPage))))
 ));

--- a/src/pages/ContributionsPage.js
+++ b/src/pages/ContributionsPage.js
@@ -1,50 +1,71 @@
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { injectIntl } from 'react-intl';
+import { injectIntl } from "react-intl";
+
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { historyPush, withModulesManager, withHistory, clearCurrentPaginationPage } from "@openimis/fe-core"
+
+import {
+  historyPush,
+  withModulesManager,
+  withHistory,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import ContributionSearcher from "../components/ContributionSearcher";
 
-
-const styles = theme => ({
-    page: theme.page,
-    fab: theme.fab
+const styles = (theme) => ({
+  page: theme.page,
+  fab: theme.fab,
 });
 
-
 class ContributionsPage extends Component {
+  onDoubleClick = (c, newTab = false) => {
+    historyPush(
+      this.props.modulesManager,
+      this.props.history,
+      "contribution.contributionOverview",
+      [c.uuid],
+      newTab
+    );
+  };
 
-    onDoubleClick = (c, newTab = false) => {
-        historyPush(this.props.modulesManager, this.props.history, "contribution.contributionOverview", [c.uuid], newTab)
-    }
+  componentDidMount = () => {
+    const moduleName = "contribution";
+    const { module } = this.props;
+    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+  };
 
-    componentDidMount = () => {
-        const moduleName = "contribution";
-        const { module } = this.props;
-        if (module !== moduleName) this.props.clearCurrentPaginationPage();
-      };
-
-    render() {
-        const { classes } = this.props;
-        return (
-            <div className={classes.page}>
-                <ContributionSearcher
-                    cacheFiltersKey="contributionsPageFiltersCache"
-                    onDoubleClick={this.onDoubleClick}
-                />
-            </div>
-        )
-    }
+  render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.page}>
+        <ContributionSearcher
+          cacheFiltersKey="contributionsPageFiltersCache"
+          onDoubleClick={this.onDoubleClick}
+        />
+      </div>
+    );
+  }
 }
 
-const mapStateToProps = state => ({
-    rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
-    module: state.core?.savedPagination?.module,
-})
+const mapStateToProps = (state) => ({
+  rights:
+    !!state.core && !!state.core.user && !!state.core.user.i_user
+      ? state.core.user.i_user.rights
+      : [],
+  module: state.core?.savedPagination?.module,
+});
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ clearCurrentPaginationPage }, dispatch);
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators({ clearCurrentPaginationPage }, dispatch);
 
-export default injectIntl(withModulesManager(
-    withHistory(connect(mapStateToProps, mapDispatchToProps)(withTheme(withStyles(styles)(ContributionsPage))))
-));
+export default injectIntl(
+  withModulesManager(
+    withHistory(
+      connect(
+        mapStateToProps,
+        mapDispatchToProps
+      )(withTheme(withStyles(styles)(ContributionsPage)))
+    )
+  )
+);


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:
- Code refactor in ContributionsPage.
- Clearing pagination state if entered the ContributionsPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ