### PR TITLE
OP-1493: do not let to save if contribution amount exceeds policy value

### DIFF
--- a/src/components/ContributionForm.js
+++ b/src/components/ContributionForm.js
@@ -140,6 +140,7 @@ class ContributionForm extends Component {
         (!contribution.payDate ||
           !contribution.payType ||
           !contribution.amount ||
+          contribution.amount > contribution.policy.value || 
           !contribution.receipt ||
           !contribution.policy ||
           contribution.validityTo ||

--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -172,7 +172,7 @@ class ContributionMasterPanel extends FormPanel {
               required
               readOnly={readOnly}
               value={edited?.amount || 0}
-              max={parseInt(edited.policy?.value, 10)}
+              max={edited.policy?.value}
               displayZero={true}
               onChange={(c) => this.updateAttribute("amount", c)}
             />

--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -172,6 +172,7 @@ class ContributionMasterPanel extends FormPanel {
               required
               readOnly={readOnly}
               value={edited?.amount || 0}
+              max={parseInt(edited.policy?.value, 10)}
               displayZero={true}
               onChange={(c) => this.updateAttribute("amount", c)}
             />

--- a/src/components/SaveContributionDialog.js
+++ b/src/components/SaveContributionDialog.js
@@ -66,23 +66,13 @@ const SaveContributionDialog = ({
                     )
                 }
                 {
-                    amount >= policyValue && (
+                    amount === policyValue && (
                         <DialogContentText>
                             {
-                                amount === policyValue && (
-                                    <FormattedMessage
-                                        module="contribution"
-                                        id="saveContributionDialog.messageEqual"
-                                    />
-                                )
-                            }
-                            {
-                                amount > policyValue && (
-                                    <FormattedMessage
-                                        module="contribution"
-                                        id="saveContributionDialog.messageHigher"
-                                    />
-                                )
+                                <FormattedMessage
+                                    module="contribution"
+                                    id="saveContributionDialog.messageEqual"
+                                />
                             }
                         </DialogContentText>
                     )
@@ -101,7 +91,7 @@ const SaveContributionDialog = ({
             <DialogActions>
 
                 {
-                    amount >= policyValue && (
+                    amount === policyValue && (
                         <Button onClick={e => onConfirm()} className={classes.primaryButton} autoFocus>
                             <FormattedMessage module="contribution" id="saveContributionDialog.ok.button" />
                         </Button>


### PR DESCRIPTION
[OP-1493](https://openimis.atlassian.net/browse/OP-1493)

Changes:
- Show warning that contribution amount can not be greater than policy value.
- If user enters more than allowed, saving not possible (save button disabled).
- Removal of the dialog after saving which says that amount is greater than policy value (as it is not possible to even save, the dialog was useless)

[OP-1493]: https://openimis.atlassian.net/browse/OP-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ