### PR TITLE
OP-1725: remove null/empty option from dropdown

### DIFF
--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -152,11 +152,10 @@ class ContributionMasterPanel extends FormPanel {
               onChange={(p) => this.updateAttribute('payer', p)}
             />
           </Grid>
-  
           <Grid item xs={3} className={classes.item}>
             <PublishedComponent
               pubRef='contribution.PremiumPaymentTypePicker'
-              withNull={true}
+              withNull={false}
               required
               readOnly={readOnly}
               value={!edited ? '' : edited.payType}


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:
- Remove the 'none/null' option from the dropdown menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ