### PR TITLE
OP-1824: extend error condition, add warning box

### DIFF
--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -13,7 +13,9 @@ import {
   ValidatedTextInput,
   PublishedComponent,
   formatMessageWithValues,
+  formatMessage,
   FormPanel,
+  WarningBox,
 } from "@openimis/fe-core";
 import {
   validateReceipt,
@@ -34,6 +36,30 @@ class ContributionMasterPanel extends FormPanel {
     const { savedCode } = this.props;
     const shouldValidate = inputValue !== savedCode;
     return shouldValidate;
+  };
+
+  renderWarning = () => {
+    const { intl, edited } = this.props;
+
+    if (edited.id) {
+      return null;
+    }
+
+    if (Number(edited.policy.value) - edited.policy.sumPremiums === 0) {
+      return (
+        <WarningBox
+          title={formatMessage(intl, 'contribution', 'warning.header')}
+          description={formatMessage(
+            intl,
+            'contribution',
+            'warning.paid.description'
+          )}
+          xs={12}
+        />
+      );
+    }
+
+    return null;
   };
 
   render() {
@@ -58,6 +84,7 @@ class ContributionMasterPanel extends FormPanel {
         <Grid container className={classes.item}>
           {!!edited && !!edited.policy && !!edited.policy.value && (
             <>
+              {this.renderWarning()}
               <Grid item xs={3} className={classes.item}>
                 <TextInput
                   module='contribution'
@@ -209,12 +236,15 @@ class ContributionMasterPanel extends FormPanel {
                 readOnly ||
                 maxInstallments === 0 ||
                 maxInstallments === 1 ||
-                (maxInstallments > 1 &&
+                (!edited.id &&
+                  maxInstallments > 1 &&
                   contributionTotalCount === maxInstallments - 1)
               }
               value={edited.amount}
               max={
-                !edited.id
+                !edited.id &&
+                edited?.amount >
+                  edited.policy?.value - edited.policy?.sumPremiums
                   ? parseFloat(
                       edited.policy?.value - edited.policy?.sumPremiums
                     ).toFixed(2)

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -74,5 +74,7 @@
     "contribution.familySummaries.insuranceNo": "Head Ins. No.",
     "contribution.familySummaries.lastName": "Head Last Name",
     "contribution.familySummaries.otherNames": "Head Given Name",
-    "contribution.familySummaries.dob": "Head Birth Date"
+    "contribution.familySummaries.dob": "Head Birth Date",
+    "contribution.warning.header": "WARNING",
+    "contribution.warning.paid.description": "The policy is already paid."
 }


### PR DESCRIPTION
[OP-1824](https://openimis.atlassian.net/browse/OP-1824)

[REQUIRED](https://github.com/openimis/openimis-fe-core_js/pull/200)

Changes:
- Displaying an error on Amount field has been improved.
- If user want to make a contribution (but policy is fully paid by previous installments), there is an information about that:
![image](https://github.com/openimis/openimis-fe-contribution_js/assets/109145288/c4d2277e-5662-4774-980b-3b7abb2e641c)


[OP-1824]: https://openimis.atlassian.net/browse/OP-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ