### PR TITLE
OP-1814: handle contribution if maxinstallments 0 / null

### DIFF
--- a/src/components/ContributionMasterPanel.js
+++ b/src/components/ContributionMasterPanel.js
@@ -45,6 +45,22 @@ class ContributionMasterPanel extends FormPanel {
       return null;
     }
 
+    if (
+      edited.amount > Number(edited.policy?.value - edited.policy?.sumPremiums)
+    ) {
+      return (
+        <WarningBox
+          title={formatMessage(intl, 'contribution', 'warning.header')}
+          description={formatMessage(
+            intl,
+            'contribution',
+            'warning.paid.exceedsPolicyValue'
+          )}
+          xs={12}
+        />
+      );
+    }
+
     if (Number(edited.policy.value) - edited.policy.sumPremiums === 0) {
       return (
         <WarningBox

--- a/src/components/PoliciesPremiumsOverview.js
+++ b/src/components/PoliciesPremiumsOverview.js
@@ -94,7 +94,7 @@ class PoliciesPremiumsOverview extends PagedDataHandler {
             )
           );
         } else if (
-          !maxInstallments == null &&
+          maxInstallments !== null &&
           maxInstallments <= pageInfo?.totalCount
         ) {
           coreAlert(

--- a/src/components/PoliciesPremiumsOverview.js
+++ b/src/components/PoliciesPremiumsOverview.js
@@ -94,7 +94,7 @@ class PoliciesPremiumsOverview extends PagedDataHandler {
             )
           );
         } else if (
-          !maxInstallments === null &&
+          !maxInstallments == null &&
           maxInstallments <= pageInfo?.totalCount
         ) {
           coreAlert(

--- a/src/components/PoliciesPremiumsOverview.js
+++ b/src/components/PoliciesPremiumsOverview.js
@@ -68,30 +68,52 @@ class PoliciesPremiumsOverview extends PagedDataHandler {
 
     checkNewPremium = () => {
         const {
-            policy,
-            modulesManager,
-            history,
-            pageInfo,
-            policySummary,
-            coreAlert,
+          policy,
+          modulesManager,
+          history,
+          pageInfo,
+          policySummary,
+          coreAlert,
+          intl,
         } = this.props;
-        if (policySummary?.product?.maxInstallments <= pageInfo?.totalCount) {
-            coreAlert(
-              formatMessage(
-                this.props.intl,
-                'contribution',
-                'addContributionDialog.maxINstallments.title'
-              ),
-              formatMessage(
-                this.props.intl,
-                'contribution',
-                'addContributionDialog.maxINstallments.message'
-              )
-            );
-        }
-        else
-            historyPush(modulesManager, history, "contribution.contributionNew", [policy.policyUuid]);
-    }
+    
+        const maxInstallments = policySummary?.product?.maxInstallments;
+    
+        // NOTE: 0 - no installments allowed, null - no limit
+        if (maxInstallments === 0) {
+          coreAlert(
+            formatMessage(
+              intl,
+              'contribution',
+              'addContributionDialog.maxINstallments.title'
+            ),
+            formatMessage(
+              intl,
+              'contribution',
+              'addContributionDialog.noInstallmentsAllowed.message'
+            )
+          );
+        } else if (
+          !maxInstallments === null &&
+          maxInstallments <= pageInfo?.totalCount
+        ) {
+          coreAlert(
+            formatMessage(
+              intl,
+              'contribution',
+              'addContributionDialog.maxINstallments.title'
+            ),
+            formatMessage(
+              intl,
+              'contribution',
+              'addContributionDialog.maxINstallments.message'
+            )
+          );
+        } else
+          historyPush(modulesManager, history, 'contribution.contributionNew', [
+            policy.policyUuid,
+          ]);
+      };
 
     addNewPremium = () => {
         const {

--- a/src/components/SaveContributionDialog.js
+++ b/src/components/SaveContributionDialog.js
@@ -79,7 +79,7 @@ const SaveContributionDialog = ({
                     )
                 }
                 {
-                    installmentsNumber >= max_installments && !max_installments == null && (
+                    installmentsNumber >= max_installments && max_installments !== null && (
                         <DialogContentText>
                             <FormattedMessage
                                 module="contribution"

--- a/src/components/SaveContributionDialog.js
+++ b/src/components/SaveContributionDialog.js
@@ -27,6 +27,8 @@ const SaveContributionDialog = ({
     const amount = parseInt(contribution.amount, 10) + sumPremiums;
     const policyValue = parseInt(contribution.policy.value, 10);
     const max_installments = contribution?.policy?.product?.maxInstallments;
+
+    console.log(installmentsNumber, max_installments)
     return (
         <Dialog
             open={!!contribution}
@@ -78,7 +80,7 @@ const SaveContributionDialog = ({
                     )
                 }
                 {
-                    installmentsNumber >= max_installments && (
+                    installmentsNumber >= max_installments && !max_installments === null && (
                         <DialogContentText>
                             <FormattedMessage
                                 module="contribution"

--- a/src/components/SaveContributionDialog.js
+++ b/src/components/SaveContributionDialog.js
@@ -79,7 +79,7 @@ const SaveContributionDialog = ({
                     )
                 }
                 {
-                    installmentsNumber >= max_installments && !max_installments === null && (
+                    installmentsNumber >= max_installments && !max_installments == null && (
                         <DialogContentText>
                             <FormattedMessage
                                 module="contribution"

--- a/src/components/SaveContributionDialog.js
+++ b/src/components/SaveContributionDialog.js
@@ -28,7 +28,6 @@ const SaveContributionDialog = ({
     const policyValue = parseInt(contribution.policy.value, 10);
     const max_installments = contribution?.policy?.product?.maxInstallments;
 
-    console.log(installmentsNumber, max_installments)
     return (
         <Dialog
             open={!!contribution}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -45,6 +45,7 @@
     "contribution.saveContributionDialog.messageHigher": "The contribution is higher than the value of the policy",
     "contribution.addContributionDialog.maxINstallments.title": "Limit of Installments Reached",
     "contribution.addContributionDialog.maxINstallments.message": "You've reached the limit of maximum installments for this plan. You can't add more contributions.",
+    "contribution.addContributionDialog.noInstallmentsAllowed.message": "No installments are allowed for this plan. You can't add any contributions.",
     "contribution.saveContributionDialog.ok.button": "OK",
     "contribution.saveContributionDialog.yes.button": "Yes",
     "contribution.saveContributionDialog.no.button": "No",
@@ -76,5 +77,6 @@
     "contribution.familySummaries.otherNames": "Head Given Name",
     "contribution.familySummaries.dob": "Head Birth Date",
     "contribution.warning.header": "WARNING",
-    "contribution.warning.paid.description": "The policy is already paid."
+    "contribution.warning.paid.description": "The policy is already paid.",
+    "contribution.warning.paid.exceedsPolicyValue": "Sum of contributions exceeds policy value. Saving not allowed."
 }


### PR DESCRIPTION
[OP-1814](https://openimis.atlassian.net/browse/OP-1814)

https://github.com/openimis/openimis-fe-product_js/pull/84
https://github.com/openimis/openimis-fe-core_js/pull/205

Changes:
- If maxInstallments is 0, adding contributions now allowed.
- If maxInstallments is null, there is no limit in terms of allowed contributions count.
- If maxInstallments > 1, there is a validation.
- Show warning if user enters and amount and the policy value is exceed.
- Lokalise keys updated.

[OP-1814]: https://openimis.atlassian.net/browse/OP-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ