### PR TITLE
set the already saved families contributions panel  in readOnly mode OP-2568

### DIFF
--- a/src/components/ContributionForm.js
+++ b/src/components/ContributionForm.js
@@ -204,6 +204,7 @@ class ContributionForm extends Component {
                 <ProgressOrError progress={fetchingContribution} error={errorContribution} />
                 {((!!fetchedContribution && !!contribution && contribution.uuid === contribution_uuid) || !contribution_uuid) && (
                     <Form
+                        hideSaveButton={overview}
                         module="contribution"
                         title={!!newContribution ? "ContributionOverview.newTitle" : "ContributionOverview.title"}
                         edited_id={contribution_uuid}

--- a/src/components/ContributionSearcher.js
+++ b/src/components/ContributionSearcher.js
@@ -53,16 +53,12 @@ class ContributionSearcher extends Component {
         let prms = Object.keys(state.filters)
             .filter(contrib => !!state.filters[contrib]['filter'])
             .map(contrib => state.filters[contrib]['filter']);
-        if (!state.beforeCursor && !state.afterCursor) {
-            prms.push(`first: ${state.pageSize}`);
-        }
+        prms.push(`first: ${state.pageSize}`);
         if (!!state.afterCursor) {
             prms.push(`after: "${state.afterCursor}"`)
-            prms.push(`first: ${state.pageSize}`);
         }
         if (!!state.beforeCursor) {
             prms.push(`before: "${state.beforeCursor}"`)
-            prms.push(`last: ${state.pageSize}`);
         }
         if (!!state.orderBy) {
             prms.push(`orderBy: ["${state.orderBy}"]`);
@@ -121,7 +117,7 @@ class ContributionSearcher extends Component {
         const formatters =  [
             c => formatDateFromISO(this.props.modulesManager, this.props.intl, c.payDate),
             c => c.payer?.name ?? "",
-            c => formatAmount(this.props.modulesManager, this.props.intl, c.amount),
+            c => formatAmount(this.props.intl, c.amount),
             c => <PublishedComponent
                 readOnly={true}
                 pubRef="contribution.PremiumPaymentTypePicker" withLabel={false} value={c.payType}

--- a/src/components/ContributionSearcher.js
+++ b/src/components/ContributionSearcher.js
@@ -53,12 +53,16 @@ class ContributionSearcher extends Component {
         let prms = Object.keys(state.filters)
             .filter(contrib => !!state.filters[contrib]['filter'])
             .map(contrib => state.filters[contrib]['filter']);
-        prms.push(`first: ${state.pageSize}`);
+        if (!state.beforeCursor && !state.afterCursor) {
+            prms.push(`first: ${state.pageSize}`);
+        }
         if (!!state.afterCursor) {
             prms.push(`after: "${state.afterCursor}"`)
+            prms.push(`first: ${state.pageSize}`);
         }
         if (!!state.beforeCursor) {
             prms.push(`before: "${state.beforeCursor}"`)
+            prms.push(`last: ${state.pageSize}`);
         }
         if (!!state.orderBy) {
             prms.push(`orderBy: ["${state.orderBy}"]`);
@@ -117,7 +121,7 @@ class ContributionSearcher extends Component {
         const formatters =  [
             c => formatDateFromISO(this.props.modulesManager, this.props.intl, c.payDate),
             c => c.payer?.name ?? "",
-            c => formatAmount(this.props.intl, c.amount),
+            c => formatAmount(this.props.modulesManager, this.props.intl, c.amount),
             c => <PublishedComponent
                 readOnly={true}
                 pubRef="contribution.PremiumPaymentTypePicker" withLabel={false} value={c.payType}

--- a/src/pages/ContributionPage.js
+++ b/src/pages/ContributionPage.js
@@ -43,12 +43,13 @@ class ContributionPage extends Component {
     }
 
     render() {
-        const { classes, rights, contribution_uuid,policy_uuid, overview } = this.props;
+        const { classes, rights, contribution_uuid,policy_uuid, overview, readOnly } = this.props;
         if (!rights.includes(RIGHT_CONTRIBUTION_EDIT)) return null;
 
         return (
             <div className={classes.page}>
                 <ContributionForm
+                    readOnly={readOnly}
                     overview={overview}
                     contribution_uuid={contribution_uuid}
                     policy_uuid={policy_uuid}


### PR DESCRIPTION
here we have set the panel of families contributions that are already saved in readonly mode and hide the save button  cause they should not be modified in that page.
 as show in the screenshot below 

<img width="1920" height="1080" alt="Capture d’écran du 2025-09-12 19-02-46" src="https://github.com/user-attachments/assets/2254abf9-2789-45c1-ad64-8f4391baa660" />


