### PR TITLE
set the family's contributions panel in readOnly mode OP-2568

### DIFF
--- a/src/components/ContributionForm.jsx
+++ b/src/components/ContributionForm.jsx
@@ -199,7 +199,9 @@ class ContributionForm extends Component {
           !contribution.policy ||
           contribution.validityTo ||
           (contribution.policy && !contribution.policy.uuid) ||
-          !isReceiptValid))
+          !isReceiptValid
+        )
+      )
     )
       return false;
     return true;
@@ -315,6 +317,7 @@ class ContributionForm extends Component {
           contribution.uuid === contribution_uuid) ||
           !contribution_uuid) && (
           <Form
+            hideSaveButton={overview}
             module="contribution"
             title={
               !!newContribution

--- a/src/pages/ContributionPage.jsx
+++ b/src/pages/ContributionPage.jsx
@@ -43,7 +43,7 @@ class ContributionPage extends Component {
     }
 
     render() {
-        const { rights, contribution_uuid,policy_uuid, overview } = this.props;
+        const { rights, contribution_uuid,policy_uuid, overview} = this.props;
         if (!rights.includes(RIGHT_CONTRIBUTION_EDIT)) return null;
 
         return (


### PR DESCRIPTION
here we have set the panel of families contributions that are already saved in readonly mode and hide the save button  cause they should not be modified in that page.
 as show in the screenshot below 

<img width="1920" height="1080" alt="Capture d’écran du 2025-09-12 19-02-46" src="https://github.com/user-attachments/assets/2254abf9-2789-45c1-ad64-8f4391baa660" />