### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/ContributionSearcher.js
+++ b/src/components/ContributionSearcher.js
@@ -3,7 +3,7 @@ import React, { Component, Fragment } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from 'react-intl';
-import {  IconButton, Tooltip } from "@material-ui/core";
+import {  Button, Tooltip } from "@material-ui/core";
 import {
    Tab as TabIcon, Delete as DeleteIcon
 } from '@material-ui/icons';
@@ -147,7 +147,7 @@ class ContributionSearcher extends Component {
     deletePremiumAction = (i) =>
         !!i.validityTo || !!i.clientMutationId ? null :
             <Tooltip title={formatMessage(this.props.intl, "contribution", "deletePremium.tooltip")}>
-                <IconButton onClick={() => this.confirmDelete(i)}><DeleteIcon /></IconButton>
+                <Button startIcon={<DeleteIcon />} onClick={() => this.confirmDelete(i)}>{formatMessage(this.props.intl, "contribution", "deletePremium.buttonText")}</Button>
             </Tooltip>
 
     itemFormatters = () => {
@@ -164,7 +164,7 @@ class ContributionSearcher extends Component {
 
             c => (
                 <Tooltip title={formatMessage(this.props.intl, "contribution", "contribution.openNewTab")}>
-                    <IconButton onClick={e => this.props.onDoubleClick(c, true)} > <TabIcon /></IconButton >
+                    <Button startIcon={<TabIcon />} onClick={e => this.props.onDoubleClick(c, true)} > {formatMessage(this.props.intl, "contribution", "contribution.openNewTab.buttonText")}</Button >
                 </Tooltip>
             )
         ];

--- a/src/components/PoliciesPremiumsOverview.js
+++ b/src/components/PoliciesPremiumsOverview.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from "redux";
 import { injectIntl } from 'react-intl';
 import _ from "lodash";
 
-import { Paper, IconButton, Grid, Divider, Typography, Tooltip } from "@material-ui/core";
+import { Paper, Button, Grid, Divider, Typography, Tooltip } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import ReplayIcon from "@material-ui/icons/Replay"
 import {
@@ -204,7 +204,9 @@ class PoliciesPremiumsOverview extends PagedDataHandler {
     deletePremiumAction = (i) =>
         !!i.validityTo || !!i.clientMutationId ? null :
             <Tooltip title={formatMessage(this.props.intl, "contribution", "deletePremium.tooltip")}>
-                <IconButton onClick={() => this.confirmDelete(i)}><DeleteIcon /></IconButton>
+                <Button onClick={() => this.confirmDelete(i)} startIcon={<DeleteIcon />}>
+                    {formatMessage(this.props.intl, "contribution", "deletePremium.buttonText")}
+                </Button>
             </Tooltip>
 
     itemFormatters = () => {
@@ -282,14 +284,18 @@ class PoliciesPremiumsOverview extends PagedDataHandler {
         const canAdd = rights.includes(RIGHT_CONTRIBUTION_ADD);
         let actions = [
             {
-                button: <IconButton onClick={this.query}><ReplayIcon /></IconButton>,
+                button: <Button onClick={this.query} startIcon={<ReplayIcon />}>
+                    {formatMessage(intl, "contribution", "reload.tooltip")}
+                </Button>,
                 tooltip: formatMessage(intl, "contribution", "reload.tooltip")
             }
         ];
         if (!!!readOnly && canAdd) {
             actions.push(
                 {
-                    button: <IconButton className={!policy ? classes.disabled : ""} onClick={!policy ? null : this.checkNewPremium}><AddIcon /></IconButton>,
+                    button: <Button className={!policy ? classes.disabled : ""} onClick={!policy ? null : this.checkNewPremium} startIcon={<AddIcon />}>
+                        {formatMessage(intl, "contribution", "addNewPremium.buttonText")}
+                    </Button>,
                     tooltip: !policy ?
                         formatMessage(intl, "contribution", "addNewPremium.tooltip.selectPolicy") :
                         formatMessage(intl, "contribution", "addNewPremium.tooltip")

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,7 @@
 {
+    "addNewPremium.buttonText": "New contribution",
+    "contribution.openNewTab.buttonText": "Open",
+    "contribution.deletePremium.buttonText": "Delete",
     "contribution.addNewPremium.tooltip": "Add new contribution",
     "contribution.reload.tooltip": "Reload",
     "contribution.addNewPremium.tooltip.selectPolicy": "Please select a policy to add a contribution",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.